### PR TITLE
refactor: update css font paths to match readme

### DIFF
--- a/fonts/icons/README.md
+++ b/fonts/icons/README.md
@@ -127,12 +127,12 @@ Place the following code in your CSS and replace `path/to/node_modules` with the
 <!-- GC Design System Fonts - Icons -->
 @font-face {
   font-family: "gcds-icons";
-  src: url("path/to/node_modules/@cdssnc/gcds-fonts/icons/gcds-icons.eot");
-  src: url("path/to/node_modules/@cdssnc/gcds-fonts/icons/gcds-icons.eot#iefix")
-      format("embedded-opentype"), url("path/to/node_modules/@cdssnc/gcds-fonts/icons/gcds-icons.ttf")
+  src: url("path/to/node_modules/@cdssnc/gcds-fonts/fonts/icons/gcds-icons.eot");
+  src: url("path/to/node_modules/@cdssnc/gcds-fonts/fonts/icons/gcds-icons.eot#iefix")
+      format("embedded-opentype"), url("path/to/node_modules/@cdssnc/gcds-fonts/fonts/icons/gcds-icons.ttf")
       format("truetype"),
-    url("path/to/node_modules/@cdssnc/gcds-fonts/icons/gcds-icons.woff") format("woff"),
-    url("path/to/node_modules/@cdssnc/gcds-fonts/icons/gcds-icons.svg") format("svg");
+    url("path/to/node_modules/@cdssnc/gcds-fonts/fonts/icons/gcds-icons.woff") format("woff"),
+    url("path/to/node_modules/@cdssnc/gcds-fonts/fonts/icons/gcds-icons.svg") format("svg");
   font-weight: normal;
   font-style: normal;
   font-display: block;

--- a/fonts/lato/gcds-lato.css
+++ b/fonts/lato/gcds-lato.css
@@ -1,19 +1,19 @@
 /*
-  Replace <path-to-file> with the correct path to
+  Replace path/to/file with the correct path to
   the gcds-lato font files in your project
 */
 @font-face {
   font-family: "Lato";
-  src: url("<path-to-file>/lato/gcds-lato.woff2") format("woff2"),
-    url("<path-to-file>/lato/gcds-lato.woff") format("woff");
+  src: url("path/to/file/gcds-lato.woff2") format("woff2"),
+    url("path/to/file/gcds-lato.woff") format("woff");
   font-weight: 700;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Lato";
-  src: url("<path-to-file>/lato/gcds-lato-italic.woff2") format("woff2"),
-    url("<path-to-file>/lato/gcds-lato-italic.woff") format("woff");
+  src: url("path/to/file/gcds-lato-italic.woff2") format("woff2"),
+    url("path/to/file/gcds-lato-italic.woff") format("woff");
   font-weight: 700;
   font-style: italic;
 }

--- a/fonts/noto-sans-mono/gcds-noto-sans-mono.css
+++ b/fonts/noto-sans-mono/gcds-noto-sans-mono.css
@@ -1,11 +1,11 @@
 /*
-  Replace <path-to-file> with the correct path to
+  Replace path/to/file with the correct path to
   the gcds-noto-sans-mono font files in your project
 */
 @font-face {
   font-family: "Noto Sans Mono";
-  src: url("<path-to-file>/gcds-noto-sans-mono.woff2") format("woff2"),
-    url("<path-to-file>/gcds-noto-sans-mono.woff") format("woff");
+  src: url("path/to/file/gcds-noto-sans-mono.woff2") format("woff2"),
+    url("path/to/file/gcds-noto-sans-mono.woff") format("woff");
   font-weight: 400;
   font-style: normal;
 }

--- a/fonts/noto-sans/gcds-noto-sans.css
+++ b/fonts/noto-sans/gcds-noto-sans.css
@@ -1,84 +1,83 @@
 /*
-  Replace <path-to-file> with the correct path to
+  Replace path/to/file with the correct path to
   the gcds-noto-sans font files in your project
 */
 @font-face {
   font-family: "Noto Sans";
-  src: url("<path-to-file>/gcds-noto-sans-light.woff2") format("woff2"),
-    url("<path-to-file>/gcds-noto-sans-light.woff") format("woff");
+  src: url("path/to/file/gcds-noto-sans-light.woff2") format("woff2"),
+    url("path/to/file/gcds-noto-sans-light.woff") format("woff");
   font-weight: 300;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Noto Sans";
-  src: url("<path-to-file>/gcds-noto-sans-light-italic.woff2") format("woff2"),
-    url("<path-to-file>/gcds-noto-sans-light-italic.woff") format("woff");
+  src: url("path/to/file/gcds-noto-sans-light-italic.woff2") format("woff2"),
+    url("path/to/file/gcds-noto-sans-light-italic.woff") format("woff");
   font-weight: 300;
   font-style: italic;
 }
 
 @font-face {
   font-family: "Noto Sans";
-  src: url("<path-to-file>/gcds-noto-sans-regular.woff2") format("woff2"),
-    url("<path-to-file>/gcds-noto-sans-regular.woff") format("woff");
+  src: url("path/to/file/gcds-noto-sans-regular.woff2") format("woff2"),
+    url("path/to/file/gcds-noto-sans-regular.woff") format("woff");
   font-weight: 400;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Noto Sans";
-  src: url("<path-to-file>/gcds-noto-sans-regular-italic.woff2") format("woff2"),
-    url("<path-to-file>/gcds-noto-sans-regular-italic.woff") format("woff");
+  src: url("path/to/file/gcds-noto-sans-regular-italic.woff2") format("woff2"),
+    url("path/to/file/gcds-noto-sans-regular-italic.woff") format("woff");
   font-weight: 400;
   font-style: italic;
 }
 
 @font-face {
   font-family: "Noto Sans";
-  src: url("<path-to-file>/gcds-noto-sans-medium.woff2") format("woff2"),
-    url("<path-to-file>/gcds-noto-sans-medium.woff") format("woff");
+  src: url("path/to/file/gcds-noto-sans-medium.woff2") format("woff2"),
+    url("path/to/file/gcds-noto-sans-medium.woff") format("woff");
   font-weight: 500;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Noto Sans";
-  src: url("<path-to-file>/gcds-noto-sans-medium-italic.woff2") format("woff2"),
-    url("<path-to-file>/gcds-noto-sans-medium-italic.woff") format("woff");
+  src: url("path/to/file/gcds-noto-sans-medium-italic.woff2") format("woff2"),
+    url("path/to/file/gcds-noto-sans-medium-italic.woff") format("woff");
   font-weight: 500;
   font-style: italic;
 }
 
 @font-face {
   font-family: "Noto Sans";
-  src: url("<path-to-file>/gcds-noto-sans-semibold.woff2") format("woff2"),
-    url("<path-to-file>/gcds-noto-sans-semibold.woff") format("woff");
+  src: url("path/to/file/gcds-noto-sans-semibold.woff2") format("woff2"),
+    url("path/to/file/gcds-noto-sans-semibold.woff") format("woff");
   font-weight: 600;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Noto Sans";
-  src: url("<path-to-file>/gcds-noto-sans-semibold-italic.woff2")
-      format("woff2"),
-    url("<path-to-file>/gcds-noto-sans-semibold-italic.woff") format("woff");
+  src: url("path/to/file/gcds-noto-sans-semibold-italic.woff2") format("woff2"),
+    url("path/to/file/gcds-noto-sans-semibold-italic.woff") format("woff");
   font-weight: 600;
   font-style: italic;
 }
 
 @font-face {
   font-family: "Noto Sans";
-  src: url("<path-to-file>/gcds-noto-sans-bold.woff2") format("woff2"),
-    url("<path-to-file>/gcds-noto-sans-bold.woff") format("woff");
+  src: url("path/to/file/gcds-noto-sans-bold.woff2") format("woff2"),
+    url("path/to/file/gcds-noto-sans-bold.woff") format("woff");
   font-weight: 700;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Noto Sans";
-  src: url("<path-to-file>/gcds-noto-sans-bold-italic.woff2") format("woff2"),
-    url("<path-to-file>/gcds-noto-sans-bold-italic.woff") format("woff");
+  src: url("path/to/file/gcds-noto-sans-bold-italic.woff2") format("woff2"),
+    url("path/to/file/gcds-noto-sans-bold-italic.woff") format("woff");
   font-weight: 700;
   font-style: italic;
 }


### PR DESCRIPTION
# Summary | Résumé

Updating the font paths in the CSS file for each font to match the readme's.