### PR TITLE
refactor: add gcds- prefix to icon + noto sans example class names

### DIFF
--- a/examples/icons/gcds-icons-example.css
+++ b/examples/icons/gcds-icons-example.css
@@ -10,8 +10,8 @@
   font-display: block;
 }
 
-[class^="icon-"],
-[class*=" icon-"] {
+[class^="gcds-icon-"],
+[class*=" gcds-icon-"] {
   /* use !important to prevent issues with browser extensions that change fonts */
   font-family: "gcds-icons" !important;
   speak: never;
@@ -24,58 +24,58 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-.icon-checkmark-circle:before {
+.gcds-icon-checkmark-circle:before {
   content: "\e908";
 }
 
-.icon-chevron-down:before {
+.gcds-icon-chevron-down:before {
   content: "\e900";
 }
 
-.icon-chevron-left:before {
+.gcds-icon-chevron-left:before {
   content: "\e901";
 }
 
-.icon-chevron-right:before {
+.gcds-icon-chevron-right:before {
   content: "\e902";
 }
 
-.icon-chevron-up:before {
+.gcds-icon-chevron-up:before {
   content: "\e903";
 }
 
-.icon-close:before {
+.gcds-icon-close:before {
   content: "\e90b";
 }
 
-.icon-download:before {
+.gcds-icon-download:before {
   content: "\e906";
 }
 
-.icon-email:before {
+.gcds-icon-email:before {
   content: "\e905";
 }
 
-.icon-exclamation-circle:before {
+.gcds-icon-exclamation-circle:before {
   content: "\e909";
 }
 
-.icon-external:before {
+.gcds-icon-external:before {
   content: "\e904";
 }
 
-.icon-information-circle:before {
+.gcds-icon-information-circle:before {
   content: "\e90a";
 }
 
-.icon-phone:before {
+.gcds-icon-phone:before {
   content: "\e90c";
 }
 
-.icon-search:before {
+.gcds-icon-search:before {
   content: "\e907";
 }
 
-.icon-warning-triangle:before {
+.gcds-icon-warning-triangle:before {
   content: "\e90d";
 }

--- a/examples/icons/gcds-icons-example.html
+++ b/examples/icons/gcds-icons-example.html
@@ -32,60 +32,60 @@
 
       <ul class="d-grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-400">
         <li class="bb-sm b-default py-200">
-          <span class="icon-checkmark-circle"></span>
-          <span class="mls"> icon-checkmark-circle</span>
+          <span class="gcds-icon-checkmark-circle"></span>
+          <span class="mls"> gcds-icon-checkmark-circle</span>
         </li>
         <li class="bb-sm b-default py-200">
-          <span class="icon-chevron-down"></span>
-          <span class="mls"> icon-chevron-down</span>
+          <span class="gcds-icon-chevron-down"></span>
+          <span class="mls"> gcds-icon-chevron-down</span>
         </li>
         <li class="bb-sm b-default py-200">
-          <span class="icon-chevron-left"></span>
-          <span class="mls"> icon-chevron-left</span>
+          <span class="gcds-icon-chevron-left"></span>
+          <span class="mls"> gcds-icon-chevron-left</span>
         </li>
         <li class="bb-sm b-default py-200">
-          <span class="icon-chevron-right"></span>
-          <span class="mls"> icon-chevron-right</span>
+          <span class="gcds-icon-chevron-right"></span>
+          <span class="mls"> gcds-icon-chevron-right</span>
         </li>
         <li class="bb-sm b-default py-200">
-          <span class="icon-chevron-up"></span>
-          <span class="mls"> icon-chevron-up</span>
+          <span class="gcds-icon-chevron-up"></span>
+          <span class="mls"> gcds-icon-chevron-up</span>
         </li>
         <li class="bb-sm b-default py-200">
-          <span class="icon-close"></span>
-          <span class="mls"> icon-close</span>
+          <span class="gcds-icon-close"></span>
+          <span class="mls"> gcds-icon-close</span>
         </li>
         <li class="bb-sm b-default py-200">
-          <span class="icon-download"></span>
-          <span class="mls"> icon-download</span>
+          <span class="gcds-icon-download"></span>
+          <span class="mls"> gcds-icon-download</span>
         </li>
         <li class="bb-sm b-default py-200">
-          <span class="icon-email"></span>
-          <span class="mls"> icon-email</span>
+          <span class="gcds-icon-email"></span>
+          <span class="mls"> gcds-icon-email</span>
         </li>
         <li class="bb-sm b-default py-200">
-          <span class="icon-exclamation-circle"></span>
-          <span class="mls"> icon-exclamation-circle</span>
+          <span class="gcds-icon-exclamation-circle"></span>
+          <span class="mls"> gcds-icon-exclamation-circle</span>
         </li>
         <li class="bb-sm b-default py-200">
-          <span class="icon-external"></span>
-          <span class="mls"> icon-external</span>
+          <span class="gcds-icon-external"></span>
+          <span class="mls"> gcds-icon-external</span>
         </li>
         <li class="bb-sm b-default py-200">
-          <span class="icon-information-circle"></span>
-          <span class="mls"> icon-information-circle</span>
+          <span class="gcds-icon-information-circle"></span>
+          <span class="mls"> gcds-icon-information-circle</span>
         </li>
         <li class="bb-sm b-default py-200">
-          <span class="icon-phone"></span>
-          <span class="mls"> icon-phone</span>
+          <span class="gcds-icon-phone"></span>
+          <span class="mls"> gcds-icon-phone</span>
         </li>
         <li class="bb-sm b-default py-200">
-          <span class="icon-search"></span>
-          <span class="mls"> icon-search</span>
+          <span class="gcds-icon-search"></span>
+          <span class="mls"> gcds-icon-search</span>
         </li>
         <li class="bb-sm b-default py-200">
-          <span class="icon-warning-triangle"></span>
-          <span class="mls"> icon-warning-triangle</span>
+          <span class="gcds-icon-warning-triangle"></span>
+          <span class="mls"> gcds-icon-warning-triangle</span>
         </li>
       </ul>
     </div>

--- a/examples/noto-sans/gcds-noto-sans-example.css
+++ b/examples/noto-sans/gcds-noto-sans-example.css
@@ -94,22 +94,22 @@ body {
 }
 
 /* Example CSS classes to show different font weights */
-.noto-sans-light {
+.gcds-noto-sans-light {
   font-weight: 300;
 }
 
-.noto-sans-regular {
+.gcds-noto-sans-regular {
   font-weight: 400;
 }
 
-.noto-sans-medium {
+.gcds-noto-sans-medium {
   font-weight: 500;
 }
 
-.noto-sans-semibold {
+.gcds-noto-sans-semibold {
   font-weight: 600;
 }
 
-.noto-sans-bold {
+.gcds-noto-sans-bold {
   font-weight: 700;
 }

--- a/fonts/icons/README.md
+++ b/fonts/icons/README.md
@@ -28,8 +28,8 @@ To use GC Design System icons in your project, place the following code in your 
   font-display: block;
 }
 
-[class^="icon-"],
-[class*=" icon-"] {
+[class^="gcds-icon-"],
+[class*=" gcds-icon-"] {
   /* use !important to prevent issues with browser extensions that change fonts */
   font-family: "gcds-icons" !important;
   speak: never;
@@ -42,59 +42,59 @@ To use GC Design System icons in your project, place the following code in your 
   -moz-osx-font-smoothing: grayscale;
 }
 
-.icon-checkmark-circle:before {
+.gcds-icon-checkmark-circle:before {
   content: "\e908";
 }
 
-.icon-chevron-down:before {
+.gcds-icon-chevron-down:before {
   content: "\e900";
 }
 
-.icon-chevron-left:before {
+.gcds-icon-chevron-left:before {
   content: "\e901";
 }
 
-.icon-chevron-right:before {
+.gcds-icon-chevron-right:before {
   content: "\e902";
 }
 
-.icon-chevron-up:before {
+.gcds-icon-chevron-up:before {
   content: "\e903";
 }
 
-.icon-close:before {
+.gcds-icon-close:before {
   content: "\e90b";
 }
 
-.icon-download:before {
+.gcds-icon-download:before {
   content: "\e906";
 }
 
-.icon-email:before {
+.gcds-icon-email:before {
   content: "\e905";
 }
 
-.icon-exclamation-circle:before {
+.gcds-icon-exclamation-circle:before {
   content: "\e909";
 }
 
-.icon-external:before {
+.gcds-icon-external:before {
   content: "\e904";
 }
 
-.icon-information-circle:before {
+.gcds-icon-information-circle:before {
   content: "\e90a";
 }
 
-.icon-phone:before {
+.gcds-icon-phone:before {
   content: "\e90c";
 }
 
-.icon-search:before {
+.gcds-icon-search:before {
   content: "\e907";
 }
 
-.icon-warning-triangle:before {
+.gcds-icon-warning-triangle:before {
   content: "\e90d";
 }
 ```
@@ -125,8 +125,8 @@ Place the following code in your CSS and replace `path/to/node_modules` with the
   font-display: block;
 }
 
-[class^="icon-"],
-[class*=" icon-"] {
+[class^="gcds-icon-"],
+[class*=" gcds-icon-"] {
   /* use !important to prevent issues with browser extensions that change fonts */
   font-family: "gcds-icons" !important;
   speak: never;
@@ -139,75 +139,75 @@ Place the following code in your CSS and replace `path/to/node_modules` with the
   -moz-osx-font-smoothing: grayscale;
 }
 
-.icon-checkmark-circle:before {
+.gcds-icon-checkmark-circle:before {
   content: "\e908";
 }
 
-.icon-chevron-down:before {
+.gcds-icon-chevron-down:before {
   content: "\e900";
 }
 
-.icon-chevron-left:before {
+.gcds-icon-chevron-left:before {
   content: "\e901";
 }
 
-.icon-chevron-right:before {
+.gcds-icon-chevron-right:before {
   content: "\e902";
 }
 
-.icon-chevron-up:before {
+.gcds-icon-chevron-up:before {
   content: "\e903";
 }
 
-.icon-close:before {
+.gcds-icon-close:before {
   content: "\e90b";
 }
 
-.icon-download:before {
+.gcds-icon-download:before {
   content: "\e906";
 }
 
-.icon-email:before {
+.gcds-icon-email:before {
   content: "\e905";
 }
 
-.icon-exclamation-circle:before {
+.gcds-icon-exclamation-circle:before {
   content: "\e909";
 }
 
-.icon-external:before {
+.gcds-icon-external:before {
   content: "\e904";
 }
 
-.icon-information-circle:before {
+.gcds-icon-information-circle:before {
   content: "\e90a";
 }
 
-.icon-phone:before {
+.gcds-icon-phone:before {
   content: "\e90c";
 }
 
-.icon-search:before {
+.gcds-icon-search:before {
   content: "\e907";
 }
 
-.icon-warning-triangle:before {
+.gcds-icon-warning-triangle:before {
   content: "\e90d";
 }
 ```
 
 ## How to use icons
 
-Open the [icons overview]() to see a list of all available GC Design System icons and find the icon class name of the icon you want to use. Apply the class to any HTML element where you want the icon to appear. Replace `icon-name` with the specific class name for the icon you want to use.
+Open the [icons overview]() to see a list of all available GC Design System icons and find the icon class name of the icon you want to use. Apply the class to any HTML element where you want the icon to appear. Replace `gcds-icon-name` with the specific class name for the icon you want to use.
 
 ```html
-<span class="icon-name"></span>
+<span class="gcds-icon-name"></span>
 ```
 
-If you want to use the close icon, for example, you need to add the class `icon-close`:
+If you want to use the close icon, for example, you need to add the class `gcds-icon-close`:
 
 ```html
-<span class="icon-close"></span>
+<span class="gcds-icon-close"></span>
 ```
 
 ## Example
@@ -244,8 +244,8 @@ Pour utiliser les icônes de Système de design GC dans votre projet, placez le 
   font-display: block;
 }
 
-[class^="icon-"],
-[class*=" icon-"] {
+[class^="gcds-icon-"],
+[class*=" gcds-icon-"] {
   /* use !important to prevent issues with browser extensions that change fonts */
   font-family: "gcds-icons" !important;
   speak: never;
@@ -258,59 +258,59 @@ Pour utiliser les icônes de Système de design GC dans votre projet, placez le 
   -moz-osx-font-smoothing: grayscale;
 }
 
-.icon-checkmark-circle:before {
+.gcds-icon-checkmark-circle:before {
   content: "\e908";
 }
 
-.icon-chevron-down:before {
+.gcds-icon-chevron-down:before {
   content: "\e900";
 }
 
-.icon-chevron-left:before {
+.gcds-icon-chevron-left:before {
   content: "\e901";
 }
 
-.icon-chevron-right:before {
+.gcds-icon-chevron-right:before {
   content: "\e902";
 }
 
-.icon-chevron-up:before {
+.gcds-icon-chevron-up:before {
   content: "\e903";
 }
 
-.icon-close:before {
+.gcds-icon-close:before {
   content: "\e90b";
 }
 
-.icon-download:before {
+.gcds-icon-download:before {
   content: "\e906";
 }
 
-.icon-email:before {
+.gcds-icon-email:before {
   content: "\e905";
 }
 
-.icon-exclamation-circle:before {
+.gcds-icon-exclamation-circle:before {
   content: "\e909";
 }
 
-.icon-external:before {
+.gcds-icon-external:before {
   content: "\e904";
 }
 
-.icon-information-circle:before {
+.gcds-icon-information-circle:before {
   content: "\e90a";
 }
 
-.icon-phone:before {
+.gcds-icon-phone:before {
   content: "\e90c";
 }
 
-.icon-search:before {
+.gcds-icon-search:before {
   content: "\e907";
 }
 
-.icon-warning-triangle:before {
+.gcds-icon-warning-triangle:before {
   content: "\e90d";
 }
 ```
@@ -341,8 +341,8 @@ Placez le code suivant dans votre CSS et remplacez `path/to/node_modules` par l'
   font-display: block;
 }
 
-[class^="icon-"],
-[class*=" icon-"] {
+[class^="gcds-icon-"],
+[class*=" gcds-icon-"] {
   /* use !important to prevent issues with browser extensions that change fonts */
   font-family: "gcds-icons" !important;
   speak: never;
@@ -355,75 +355,75 @@ Placez le code suivant dans votre CSS et remplacez `path/to/node_modules` par l'
   -moz-osx-font-smoothing: grayscale;
 }
 
-.icon-checkmark-circle:before {
+.gcds-icon-checkmark-circle:before {
   content: "\e908";
 }
 
-.icon-chevron-down:before {
+.gcds-icon-chevron-down:before {
   content: "\e900";
 }
 
-.icon-chevron-left:before {
+.gcds-icon-chevron-left:before {
   content: "\e901";
 }
 
-.icon-chevron-right:before {
+.gcds-icon-chevron-right:before {
   content: "\e902";
 }
 
-.icon-chevron-up:before {
+.gcds-icon-chevron-up:before {
   content: "\e903";
 }
 
-.icon-close:before {
+.gcds-icon-close:before {
   content: "\e90b";
 }
 
-.icon-download:before {
+.gcds-icon-download:before {
   content: "\e906";
 }
 
-.icon-email:before {
+.gcds-icon-email:before {
   content: "\e905";
 }
 
-.icon-exclamation-circle:before {
+.gcds-icon-exclamation-circle:before {
   content: "\e909";
 }
 
-.icon-external:before {
+.gcds-icon-external:before {
   content: "\e904";
 }
 
-.icon-information-circle:before {
+.gcds-icon-information-circle:before {
   content: "\e90a";
 }
 
-.icon-phone:before {
+.gcds-icon-phone:before {
   content: "\e90c";
 }
 
-.icon-search:before {
+.gcds-icon-search:before {
   content: "\e907";
 }
 
-.icon-warning-triangle:before {
+.gcds-icon-warning-triangle:before {
   content: "\e90d";
 }
 ```
 
 ## Comment utiliser les icônes
 
-Ouvrez l'[aperçu des icônes]() pour afficher la liste de toutes les icônes de Système de design GC disponibles et trouver le nom de classe de l'icône que vous souhaitez utiliser. Appliquez la classe à n'importe quel élément HTML auquel vous voulez ajouter l'icône. Remplacez `icon-name` par le nom de classe de l'icône que vous souhaitez utiliser.
+Ouvrez l'[aperçu des icônes]() pour afficher la liste de toutes les icônes de Système de design GC disponibles et trouver le nom de classe de l'icône que vous souhaitez utiliser. Appliquez la classe à n'importe quel élément HTML auquel vous voulez ajouter l'icône. Remplacez `gcds-icon-name` par le nom de classe de l'icône que vous souhaitez utiliser.
 
 ```html
-<span class="icon-name"></span>
+<span class="gcds-icon-name"></span>
 ```
 
-Si vous voulez utiliser l'icône « fermer », par exemple, vous devez ajouter la classe `icon-close` :
+Si vous voulez utiliser l'icône « fermer », par exemple, vous devez ajouter la classe `gcds-icon-close` :
 
 ```html
-<span class="icon-close"></span>
+<span class="gcds-icon-close"></span>
 ```
 
 ## Exemple

--- a/fonts/icons/gcds-icons.css
+++ b/fonts/icons/gcds-icons.css
@@ -14,8 +14,8 @@
   font-display: block;
 }
 
-[class^="icon-"],
-[class*=" icon-"] {
+[class^="gcds-icon-"],
+[class*=" gcds-icon-"] {
   /* use !important to prevent issues with browser extensions that change fonts */
   font-family: "gcds-icons" !important;
   speak: never;
@@ -28,74 +28,74 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-.icon-chevron-down:before {
+.gcds-icon-chevron-down:before {
   content: "\e900";
 }
 
-.icon-chevron-left:before {
+.gcds-icon-chevron-left:before {
   content: "\e901";
 }
 
-.icon-chevron-right:before {
+.gcds-icon-chevron-right:before {
   content: "\e902";
 }
 
-.icon-chevron-up:before {
+.gcds-icon-chevron-up:before {
   content: "\e903";
 }
 
-.icon-external:before {
+.gcds-icon-external:before {
   content: "\e904";
 }
 
-.icon-email:before {
+.gcds-icon-email:before {
   content: "\e905";
 }
 
-.icon-download:before {
+.gcds-icon-download:before {
   content: "\e906";
 }
 
-.icon-warning-triangle-outline:before {
+.gcds-icon-warning-triangle-outline:before {
   content: "\e907";
 }
 
-.icon-search:before {
+.gcds-icon-search:before {
   content: "\e908";
 }
 
-.icon-checkmark-circle-solid:before {
+.gcds-icon-checkmark-circle-solid:before {
   content: "\e909";
 }
 
-.icon-exclamation-circle-solid:before {
+.gcds-icon-exclamation-circle-solid:before {
   content: "\e90a";
 }
 
-.icon-information-circle-solid:before {
+.gcds-icon-information-circle-solid:before {
   content: "\e90b";
 }
 
-.icon-close:before {
+.gcds-icon-close:before {
   content: "\e90c";
 }
 
-.icon-phone:before {
+.gcds-icon-phone:before {
   content: "\e90d";
 }
 
-.icon-warning-triangle-solid:before {
+.gcds-icon-warning-triangle-solid:before {
   content: "\e90e";
 }
 
-.icon-checkmark-circle-outline:before {
+.gcds-icon-checkmark-circle-outline:before {
   content: "\e90f";
 }
 
-.icon-exclamation-circle-outline:before {
+.gcds-icon-exclamation-circle-outline:before {
   content: "\e910";
 }
 
-.icon-information-circle-outline:before {
+.gcds-icon-information-circle-outline:before {
   content: "\e911";
 }


### PR DESCRIPTION
# Summary | Résumé

Adding in our `gcds-` prefix to all icon classes as well as the Noto Sans classes in the example HTML to avoid any accidental overwrites from other icon or font libraries.