### PR TITLE
docs: update readmes to reference font names with GCDS connection

### DIFF
--- a/fonts/icons/README.md
+++ b/fonts/icons/README.md
@@ -1,8 +1,8 @@
 ([Français](#polices-de-système-de-design-gc--icônes))
 
-# GC Design System Fonts - Icons
+# GC Design System Fonts - GCDS Icons
 
-GC Design System Fonts - Icons is a custom icon font created for the GC Design System. Icon fonts provide scalable vector icons that enhance performance, maintain consistency, and offer easy customization through CSS. Icons are used for visual communication that helps a person understand context.
+GC Design System Fonts - GCDS Icons is a custom icon font created for the GC Design System. Icon fonts provide scalable vector icons that enhance performance, maintain consistency, and offer easy customization through CSS. Icons are used for visual communication that helps a person understand context.
 
 To remove the reliance on a third-party icon library (Font Awesome) we built a custom icon font. This also provides the GC Design System with more control over icons available to users. FontAwesome provides an extensive collection of icons, most of which will not be used for our components. By limiting the scope of available icons, we aim to prevent misuse and provide clear guidelines on the appropriate usage of each icon.
 
@@ -216,9 +216,9 @@ Open the [icons overview]() to see a list of all available GC Design System icon
 
 ---
 
-# Polices de Système de design GC — Icônes
+# Polices de Système de design GC — GCDS Icônes
 
-Polices de Système de design GC — Icônes est une police d'icônes sur mesure créée pour Système de design GC. Les polices d'icônes fournissent des icônes vectorielles redimensionnables qui améliorent la performance, assurent l'uniformité et offrent une personnalisation facile par le biais de CSS. Les icônes sont utilisées pour communiquer visuellement et aider les gens à comprendre le contexte.
+Polices de Système de design GC — GCDS Icônes est une police d'icônes sur mesure créée pour Système de design GC. Les polices d'icônes fournissent des icônes vectorielles redimensionnables qui améliorent la performance, assurent l'uniformité et offrent une personnalisation facile par le biais de CSS. Les icônes sont utilisées pour communiquer visuellement et aider les gens à comprendre le contexte.
 
 Pour éviter de recourir à une bibliothèque d'icônes tierce (Font Awesome), nous avons créé une police d'icônes sur mesure. Nous pouvons ainsi mieux contrôler les icônes mises à la disposition des utilisatrices et utilisateurs de Système de design GC. Font Awesome fournit une vaste collection d'icônes, dont la plupart ne seront pas utilisées pour nos composants. En limitant la quantité d'icônes disponibles, nous visons à prévenir les mauvais usages et à fournir des directives claires sur l'usage approprié de chaque icône.
 

--- a/fonts/lato/README.md
+++ b/fonts/lato/README.md
@@ -2,13 +2,13 @@
 
 # GC Design System Fonts - Lato
 
-GC Design System headings use the font `Lato`.
+GC Design System headings use the open-source font `Lato`.
 
 ## Installation
 
 ### Install `Lato` font with CDN
 
-To use the GC Design System font `Lato` in your project, place the following code in your CSS or include the [gcds-lato.css](https://github.com/cds-snc/gcds-fonts/blob/main/fonts/lato/gcds-lato.css) file in your project:
+To use the `Lato` font in your project, place the following code in your CSS or include the [gcds-lato.css](https://github.com/cds-snc/gcds-fonts/blob/main/fonts/lato/gcds-lato.css) file in your project:
 
 ```css
 <!-- GC Design System Fonts - Lato -->
@@ -86,19 +86,19 @@ h6 {
 
 ## Example
 
-Open the [`Lato` example]() to see a list of all heading levels using the GC Design System `Lato` font. You can find the code for the `Lato` example page in the [examples folder](https://github.com/cds-snc/gcds-fonts/tree/main/examples/lato).
+Open the [`Lato` example]() to see a list of all heading levels using the `Lato` font. You can find the code for the `Lato` example page in the [examples folder](https://github.com/cds-snc/gcds-fonts/tree/main/examples/lato).
 
 ---
 
 # Polices de Système de design GC — Lato
 
-Les titres de Système de design GC utilisent la police `Lato`.
+Les titres de Système de design GC utilisent la police à source ouverte `Lato`.
 
 ## Installation
 
 ### Installer la police `Lato` avec le CDN
 
-Pour utiliser la police `Lato` de Système de design GC dans votre projet, placez le code suivant dans votre CSS ou incluez le fichier [gcds-lato.css](https://github.com/cds-snc/gcds-fonts/blob/main/fonts/lato/gcds-lato.css) dans votre projet :
+Pour utiliser la police `Lato` dans votre projet, placez le code suivant dans votre CSS ou incluez le fichier [gcds-lato.css](https://github.com/cds-snc/gcds-fonts/blob/main/fonts/lato/gcds-lato.css) dans votre projet :
 
 ```css
 <!-- Polices de Système de design GC — Lato -->
@@ -176,4 +176,4 @@ h6 {
 
 ## Exemple
 
-Ouvrez l'[exemple `Lato`]() pour afficher la liste de tous les niveaux de titre utilisant la police `Lato` de Système de design GC. Vous trouverez le code accompagnant l'exemple `Lato` dans le dossier [exemples](https://github.com/cds-snc/gcds-fonts/tree/main/examples/lato).
+Ouvrez l'[exemple `Lato`]() pour afficher la liste de tous les niveaux de titre utilisant la police `Lato`. Vous trouverez le code accompagnant l'exemple `Lato` dans le dossier [exemples](https://github.com/cds-snc/gcds-fonts/tree/main/examples/lato).

--- a/fonts/noto-sans-mono/README.md
+++ b/fonts/noto-sans-mono/README.md
@@ -2,13 +2,13 @@
 
 # GC Design System Fonts - Noto Sans Mono
 
-Use GC Design System's `Noto Sans Mono` font when citing code to give specific code examples.
+GC Design System code examples use the open-source font `Noto Sans Mono`.
 
 ## Installation
 
 ### Install `Noto Sans Mono` font with CDN
 
-To use the GC Design System font `Noto Sans Mono` in your project, place the following code in your CSS or include the [gcds-noto-sans-mono.css](https://github.com/cds-snc/gcds-fonts/blob/main/fonts/noto-sans-mono/gcds-noto-sans-mono.css) file in your project:
+To use the `Noto Sans Mono` font in your project, place the following code in your CSS or include the [gcds-noto-sans-mono.css](https://github.com/cds-snc/gcds-fonts/blob/main/fonts/noto-sans-mono/gcds-noto-sans-mono.css) file in your project:
 
 ```css
 <!-- GC Design System Fonts - Noto Sans Mono -->
@@ -56,19 +56,19 @@ code {
 
 ## Example
 
-Open the [`Noto Sans Mono` example]() to see a code example using the GC Design System `Noto Sans Mono` font. You can find the code for the `Noto Sans Mono` example page in the [examples folder](https://github.com/cds-snc/gcds-fonts/tree/main/examples/noto-sans-mono).
+Open the [`Noto Sans Mono` example]() to see a code example using the `Noto Sans Mono` font. You can find the code for the `Noto Sans Mono` example page in the [examples folder](https://github.com/cds-snc/gcds-fonts/tree/main/examples/noto-sans-mono).
 
 ---
 
 # Polices de Système de design GC — Noto Sans Mono
 
-Utilisez la police de Système de design GC `Noto Sans Mono` lorsque vous citez du code pour donner des exemples de code précis.
+Les exemples de code de Système de design GC utilisent la police à source ouverte `Noto Sans Mono`.
 
 ## Installation
 
 ### Installer la police `Noto Sans Mono` avec le CDN
 
-Pour utiliser la police `Noto Sans Mono` de Système de design GC dans votre projet, placez le code suivant dans votre CSS ou incluez le fichier [gcds-noto-sans-mono.css](https://github.com/cds-snc/gcds-fonts/blob/main/fonts/noto-sans-mono/gcds-noto-sans-mono.css) dans votre projet :
+Pour utiliser la police `Noto Sans Mono` dans votre projet, placez le code suivant dans votre CSS ou incluez le fichier [gcds-noto-sans-mono.css](https://github.com/cds-snc/gcds-fonts/blob/main/fonts/noto-sans-mono/gcds-noto-sans-mono.css) dans votre projet :
 
 ```css
 <!-- Polices de Système de design GC — Noto Sans Mono -->
@@ -116,4 +116,4 @@ code {
 
 ## Exemple
 
-Ouvrez l'[exemple `Noto Sans Mono`]() pour voir un exemple de code utilisant la police `Noto Sans Mono` de Système de design GC. Vous trouverez le code accompagnant l'exemple `Noto Sans Mono` dans le dossier [exemples](https://github.com/cds-snc/gcds-fonts/tree/main/examples/noto-sans-mono).
+Ouvrez l'[exemple `Noto Sans Mono`]() pour voir un exemple de code utilisant la police `Noto Sans Mono`. Vous trouverez le code accompagnant l'exemple `Noto Sans Mono` dans le dossier [exemples](https://github.com/cds-snc/gcds-fonts/tree/main/examples/noto-sans-mono).

--- a/fonts/noto-sans/README.md
+++ b/fonts/noto-sans/README.md
@@ -2,112 +2,92 @@
 
 # GC Design System Fonts - Noto Sans
 
-GC Design System paragraphs and other, non-heading text use the font `Noto Sans`.
+GC Design System paragraphs and other, non-heading text use the open-source font `Noto Sans`.
 
 ## Installation
 
 ### Install `Noto Sans` font with CDN
 
-To use the GC Design System font `Noto Sans` in your project, place the following code in your CSS or include the [gcds-noto-sans.css](https://github.com/cds-snc/gcds-fonts/blob/main/fonts/noto-sans/gcds-noto-sans.css) file in your project:
+To use the `Noto Sans` font in your project, place the following code in your CSS or include the [gcds-noto-sans.css](https://github.com/cds-snc/gcds-fonts/blob/main/fonts/noto-sans/gcds-noto-sans.css) file in your project:
 
 ```css
 <!-- GC Design System Fonts - Noto Sans -->
 @font-face {
   font-family: "Noto Sans";
-  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-light.woff2")
-      format("woff2"),
-       url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-light.woff")
-      format("woff");
+  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-light.woff2") format("woff2"),
+       url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-light.woff") format("woff");
   font-weight: 300;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Noto Sans";
-  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-light-italic.woff2")
-      format("woff2"),
-       url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-light-italic.woff")
-      format("woff");
+  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-light-italic.woff2") format("woff2"),
+       url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-light-italic.woff") format("woff");
   font-weight: 300;
   font-style: italic;
 }
 
 @font-face {
   font-family: "Noto Sans";
-  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-regular.woff2")
-      format("woff2"),
-       url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-regular.woff")
-      format("woff");
+  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-regular.woff2") format("woff2"),
+       url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-regular.woff") format("woff");
   font-weight: 400;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Noto Sans";
-  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-regular-italic.woff2")
-      format("woff2"),
-       url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-regular-italic.woff")
-      format("woff");
+  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-regular-italic.woff2") format("woff2"),
+       url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-regular-italic.woff") format("woff");
   font-weight: 400;
   font-style: italic;
 }
 
 @font-face {
   font-family: "Noto Sans";
-  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-medium.woff2")
-      format("woff2"),
-       url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-medium.woff")
-      format("woff");
+  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-medium.woff2") format("woff2"),
+       url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-medium.woff") format("woff");
   font-weight: 500;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Noto Sans";
-  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-medium-italic.woff2")
-      format("woff2"),
-       url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-medium-italic.woff")
-      format("woff");
+  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-medium-italic.woff2") format("woff2"),
+       url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-medium-italic.woff") format("woff");
   font-weight: 500;
   font-style: italic;
 }
 
 @font-face {
   font-family: "Noto Sans";
-  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-semibold.woff2")
-      format("woff2"),
-       url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-semibold.woff")
-      format("woff");
+  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-semibold.woff2") format("woff2"),
+       url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-semibold.woff") format("woff");
   font-weight: 600;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Noto Sans";
-  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-semibold-italic.woff2")
-      format("woff2"),
-       url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-semibold-italic.woff")
-      format("woff");
+  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-semibold-italic.woff2") format("woff2"),
+       url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-semibold-italic.woff") format("woff");
   font-weight: 600;
   font-style: italic;
 }
 
 @font-face {
   font-family: "Noto Sans";
-  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-bold.woff2")
-      format("woff2"),
-       url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-bold.woff")
-      format("woff");
+  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-bold.woff2") format("woff2"),
+       url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-bold.woff") format("woff");
   font-weight: 700;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Noto Sans";
-  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-bold-italic.woff2")
-      format("woff2"),
-       url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-bold-italic.woff")
-      format("woff");
+  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-bold-italic.woff2") format("woff2"),
+       url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-bold-italic.woff") format("woff");
   font-weight: 700;
   font-style: italic;
 }
@@ -134,8 +114,7 @@ Place the following code in your CSS and replace `path/to/node_modules` with the
 @font-face {
   font-family: "Noto Sans";
   src: url("path/to/node_modules/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-light.woff2") format("woff2"),
-       url("path/to/node_modules/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-light.woff")
-      format("woff");
+       url("path/to/node_modules/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-light.woff") format("woff");
   font-weight: 300;
   font-style: normal;
 }
@@ -191,7 +170,7 @@ Place the following code in your CSS and replace `path/to/node_modules` with the
 @font-face {
   font-family: "Noto Sans";
   src: url("path/to/node_modules/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-semibold-italic.woff2") format("woff2"),
-    url("path/to/node_modules/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-semibold-italic.woff") format("woff");
+       url("path/to/node_modules/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-semibold-italic.woff") format("woff");
   font-weight: 600;
   font-style: italic;
 }
@@ -221,108 +200,98 @@ body {
 
 ## Example
 
-Open the [`Noto Sans` example]() to see a list of all supported font weights for the GC Design System `Noto Sans` font. You can find the code for the `Noto Sans` example page in the [examples folder](https://github.com/cds-snc/gcds-fonts/tree/main/examples/noto-sans).
+Open the [`Noto Sans` example]() to see a list of all supported font weights for the `Noto Sans` font. You can find the code for the `Noto Sans` example page in the [examples folder](https://github.com/cds-snc/gcds-fonts/tree/main/examples/noto-sans).
 
 ---
 
 # Polices de Système de design GC — Noto Sans
 
-Les paragraphes de Système de design GC, ainsi que les autres éléments textuels qui ne sont pas des titres, utilisent la police `Noto Sans`.
+Les paragraphes de Système de design GC, ainsi que les autres éléments textuels qui ne sont pas des titres, utilisent la police à source ouverte `Noto Sans`.
 
 ## Installation
 
 ### Installer la police `Noto Sans` avec le CDN
 
-Pour utiliser la police `Noto Sans` de Système de design GC dans votre projet, placez le code suivant dans votre CSS ou incluez le fichier [gcds-noto-sans.css](https://github.com/cds-snc/gcds-fonts/blob/main/fonts/noto-sans/gcds-noto-sans.css) dans votre projet :
+Pour utiliser la police `Noto Sans` dans votre projet, placez le code suivant dans votre CSS ou incluez le fichier [gcds-noto-sans.css](https://github.com/cds-snc/gcds-fonts/blob/main/fonts/noto-sans/gcds-noto-sans.css) dans votre projet :
 
 ```css
 <!-- Polices de Système de design GC — Noto Sans -->
 @font-face {
   font-family: "Noto Sans";
-  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-light.woff2")
-      format("woff2"), url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-light.woff")
-      format("woff");
+  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-light.woff2") format("woff2"),
+       url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-light.woff") format("woff");
   font-weight: 300;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Noto Sans";
-  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-light-italic.woff2")
-      format("woff2"), url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-light-italic.woff")
-      format("woff");
+  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-light-italic.woff2") format("woff2"),
+       url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-light-italic.woff") format("woff");
   font-weight: 300;
   font-style: italic;
 }
 
 @font-face {
   font-family: "Noto Sans";
-  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-regular.woff2")
-      format("woff2"), url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-regular.woff")
-      format("woff");
+  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-regular.woff2") format("woff2"),
+       url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-regular.woff") format("woff");
   font-weight: 400;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Noto Sans";
-  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-regular-italic.woff2")
-      format("woff2"), url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-regular-italic.woff")
-      format("woff");
+  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-regular-italic.woff2") format("woff2"),
+       url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-regular-italic.woff") format("woff");
   font-weight: 400;
   font-style: italic;
 }
 
 @font-face {
   font-family: "Noto Sans";
-  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-medium.woff2")
-      format("woff2"), url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-medium.woff")
-      format("woff");
+  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-medium.woff2") format("woff2"),
+       url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-medium.woff") format("woff");
   font-weight: 500;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Noto Sans";
-  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-medium-italic.woff2")
-      format("woff2"), url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-medium-italic.woff")
-      format("woff");
+  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-medium-italic.woff2") format("woff2"),
+       url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-medium-italic.woff") format("woff");
   font-weight: 500;
   font-style: italic;
 }
 
 @font-face {
   font-family: "Noto Sans";
-  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-semibold.woff2")
-      format("woff2"), url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-semibold.woff")
-      format("woff");
+  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-semibold.woff2") format("woff2"),
+       url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-semibold.woff") format("woff");
   font-weight: 600;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Noto Sans";
-  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-semibold-italic.woff2")
-      format("woff2"), url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-semibold-italic.woff")
-      format("woff");
+  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-semibold-italic.woff2") format("woff2"),
+       url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-semibold-italic.woff") format("woff");
   font-weight: 600;
   font-style: italic;
 }
 
 @font-face {
   font-family: "Noto Sans";
-  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-bold.woff2")
-      format("woff2"), url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-bold.woff")
-      format("woff");
+  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-bold.woff2") format("woff2"),
+       url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-bold.woff") format("woff");
   font-weight: 700;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Noto Sans";
-  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-bold-italic.woff2")
-      format("woff2"), url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-bold-italic.woff")
-      format("woff");
+  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-bold-italic.woff2") format("woff2"),
+       url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-bold-italic.woff") format("woff");
   font-weight: 700;
   font-style: italic;
 }
@@ -349,8 +318,7 @@ Placez le code suivant dans votre CSS et remplacez `path/to/node_modules` par l'
 @font-face {
   font-family: "Noto Sans";
   src: url("path/to/node_modules/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-light.woff2") format("woff2"),
-       url("path/to/node_modules/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-light.woff")
-      format("woff");
+       url("path/to/node_modules/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-light.woff") format("woff");
   font-weight: 300;
   font-style: normal;
 }
@@ -406,7 +374,7 @@ Placez le code suivant dans votre CSS et remplacez `path/to/node_modules` par l'
 @font-face {
   font-family: "Noto Sans";
   src: url("path/to/node_modules/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-semibold-italic.woff2") format("woff2"),
-    url("path/to/node_modules/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-semibold-italic.woff") format("woff");
+       url("path/to/node_modules/@cdssnc/gcds-fonts@1.0.0/fonts/noto-sans/gcds-noto-sans-semibold-italic.woff") format("woff");
   font-weight: 600;
   font-style: italic;
 }
@@ -436,4 +404,4 @@ body {
 
 ## Exemple
 
-Ouvrez l'[exemple `Noto Sans`]()pour afficher la liste de toutes les graisses de police prises en charge pour la police `Noto Sans` de Système de design GC. Vous trouverez le code accompagnant l'exemple `Noto Sans` dans le dossier [exemples](https://github.com/cds-snc/gcds-fonts/tree/main/examples/noto-sans).
+Ouvrez l'[exemple `Noto Sans`]()pour afficher la liste de toutes les graisses de police prises en charge pour la police `Noto Sans`. Vous trouverez le code accompagnant l'exemple `Noto Sans` dans le dossier [exemples](https://github.com/cds-snc/gcds-fonts/tree/main/examples/noto-sans).


### PR DESCRIPTION
# Summary | Résumé

Updated the font readme's and removed the "GC Design System" in front of the font names to avoid any false impression of us having built those open-source fonts ourselves.