### PR TITLE
feat: add fonts demo

### DIFF
--- a/examples/example.css
+++ b/examples/example.css
@@ -1,0 +1,246 @@
+/* ----- GC Design System Fonts - Icons ----- */
+@font-face {
+  font-family: "gcds-icons";
+  src: url("../fonts/icons/gcds-icons.eot");
+  src: url("../fonts/icons/gcds-icons.eot#iefix") format("embedded-opentype"),
+    url("../fonts/icons/gcds-icons.ttf") format("truetype"),
+    url("../fonts/icons/gcds-icons.woff") format("woff"),
+    url("../fonts/icons/gcds-icons.svg") format("svg");
+  font-weight: normal;
+  font-style: normal;
+  font-display: block;
+}
+
+[class^="gcds-icon-"],
+[class*=" gcds-icon-"] {
+  /* use !important to prevent issues with browser extensions that change fonts */
+  font-family: "gcds-icons" !important;
+  speak: never;
+  font-style: normal;
+  font-weight: normal;
+  font-variant: normal;
+  text-transform: none;
+  line-height: 1;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.gcds-icon-checkmark-circle:before {
+  content: "\e908";
+}
+
+.gcds-icon-chevron-down:before {
+  content: "\e900";
+}
+
+.gcds-icon-chevron-left:before {
+  content: "\e901";
+}
+
+.gcds-icon-chevron-right:before {
+  content: "\e902";
+}
+
+.gcds-icon-chevron-up:before {
+  content: "\e903";
+}
+
+.gcds-icon-close:before {
+  content: "\e90b";
+}
+
+.gcds-icon-download:before {
+  content: "\e906";
+}
+
+.gcds-icon-email:before {
+  content: "\e905";
+}
+
+.gcds-icon-exclamation-circle:before {
+  content: "\e909";
+}
+
+.gcds-icon-external:before {
+  content: "\e904";
+}
+
+.gcds-icon-information-circle:before {
+  content: "\e90a";
+}
+
+.gcds-icon-phone:before {
+  content: "\e90c";
+}
+
+.gcds-icon-search:before {
+  content: "\e907";
+}
+
+.gcds-icon-warning-triangle:before {
+  content: "\e90d";
+}
+
+/* ----- GC Design System Fonts - Lato ----- */
+
+@font-face {
+  font-family: "Lato";
+  src: url("../../fonts/lato/gcds-lato.woff2") format("woff2"),
+    url("../../fonts/lato/gcds-lato.woff") format("woff");
+  font-weight: 700;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: "Lato";
+  src: url("../../fonts/lato/gcds-lato-italic.woff2") format("woff2"),
+    url("../../fonts/lato/gcds-lato-italic.woff") format("woff");
+  font-weight: 700;
+  font-style: italic;
+}
+
+/* Set "Lato" + fallback as the heading font */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: "Lato", sans-serif;
+  font-weight: 700;
+}
+
+/* ----- GC Design System Fonts - Noto Sans ----- */
+
+@font-face {
+  font-family: "Noto Sans";
+  src: url("../../fonts/noto-sans/gcds-noto-sans-light.woff2") format("woff2"),
+    url("../../fonts/noto-sans/gcds-noto-sans-light.woff") format("woff");
+  font-weight: 300;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: "Noto Sans";
+  src: url("../../fonts/noto-sans/gcds-noto-sans-light-italic.woff2")
+      format("woff2"),
+    url("../../fonts/noto-sans/gcds-noto-sans-light-italic.woff") format("woff");
+  font-weight: 300;
+  font-style: italic;
+}
+
+@font-face {
+  font-family: "Noto Sans";
+  src: url("../../fonts/noto-sans/gcds-noto-sans-regular.woff2") format("woff2"),
+    url("../../fonts/noto-sans/gcds-noto-sans-regular.woff") format("woff");
+  font-weight: 400;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: "Noto Sans";
+  src: url("../../fonts/noto-sans/gcds-noto-sans-regular-italic.woff2")
+      format("woff2"),
+    url("../../fonts/noto-sans/gcds-noto-sans-regular-italic.woff")
+      format("woff");
+  font-weight: 400;
+  font-style: italic;
+}
+
+@font-face {
+  font-family: "Noto Sans";
+  src: url("<path-to-file>/fonts/gcds-noto-sans-medium.woff2") format("woff2"),
+    url("<path-to-file>/fonts/gcds-noto-sans-medium.woff") format("woff");
+  font-weight: 500;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: "Noto Sans";
+  src: url("../../fonts/noto-sans/gcds-noto-sans-medium-italic.woff2")
+      format("woff2"),
+    url("../../fonts/noto-sans/gcds-noto-sans-medium-italic.woff")
+      format("woff");
+  font-weight: 500;
+  font-style: italic;
+}
+
+@font-face {
+  font-family: "Noto Sans";
+  src: url("../../fonts/noto-sans/gcds-noto-sans-semibold.woff2")
+      format("woff2"),
+    url("../../fonts/noto-sans/gcds-noto-sans-semibold.woff") format("woff");
+  font-weight: 600;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: "Noto Sans";
+  src: url("../../fonts/noto-sans/gcds-noto-sans-semibold-italic.woff2")
+      format("woff2"),
+    url("../../fonts/noto-sans/gcds-noto-sans-semibold-italic.woff")
+      format("woff");
+  font-weight: 600;
+  font-style: italic;
+}
+
+@font-face {
+  font-family: "Noto Sans";
+  src: url("../../fonts/noto-sans/gcds-noto-sans-bold.woff2") format("woff2"),
+    url("../../fonts/noto-sans/gcds-noto-sans-bold.woff") format("woff");
+  font-weight: 700;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: "Noto Sans";
+  src: url("../../fonts/noto-sans/gcds-noto-sans-bold-italic.woff2")
+      format("woff2"),
+    url("../../fonts/noto-sans/gcds-noto-sans-bold-italic.woff") format("woff");
+  font-weight: 700;
+  font-style: italic;
+}
+
+/* Set "Noto Sans" + fallback as the default body font */
+body {
+  font-family: "Noto Sans", sans-serif;
+  font-weight: 400;
+}
+
+/* Example CSS classes to show different font weights */
+.gcds-noto-sans-light {
+  font-weight: 300;
+}
+
+.gcds-noto-sans-regular {
+  font-weight: 400;
+}
+
+.gcds-noto-sans-medium {
+  font-weight: 500;
+}
+
+.gcds-noto-sans-semibold {
+  font-weight: 600;
+}
+
+.gcds-noto-sans-bold {
+  font-weight: 700;
+}
+
+/* ----- GC Design System Fonts - Noto Sans Mono ----- */
+
+@font-face {
+  font-family: "Noto Sans Mono";
+  src: url("../../fonts/noto-sans-mono/gcds-noto-sans-mono.woff2")
+      format("woff2"),
+    url("../../fonts/noto-sans-mono/gcds-noto-sans-mono.woff") format("woff");
+  font-weight: 400;
+  font-style: normal;
+}
+
+/* Set "Noto Sans Mono" + fallback as the code font */
+code {
+  font-family: "Noto Sans Mono", monospace;
+  font-weight: 400;
+}

--- a/examples/icons/gcds-icons-example.html
+++ b/examples/icons/gcds-icons-example.html
@@ -27,67 +27,67 @@
     <link rel="stylesheet" href="gcds-icons-example.css" />
   </head>
   <body>
-    <div class="container-xl mx-auto my-400 lg:my-600 px-400 xl:px-0">
-      <h1 class="mb-400">GC Design System Fonts - Icons</h1>
+    <main class="container-xl mx-auto my-300 lg:my-600 px-300 xl:px-0">
+      <h1 class="mb-300">GC Design System Fonts - Icons</h1>
 
-      <ul class="d-grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-400">
-        <li class="bb-sm b-default py-200">
+      <ul class="d-grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-300">
+        <li class="bb-sm b-default py-150">
           <span class="gcds-icon-checkmark-circle"></span>
           <span class="mls"> gcds-icon-checkmark-circle</span>
         </li>
-        <li class="bb-sm b-default py-200">
+        <li class="bb-sm b-default py-150">
           <span class="gcds-icon-chevron-down"></span>
           <span class="mls"> gcds-icon-chevron-down</span>
         </li>
-        <li class="bb-sm b-default py-200">
+        <li class="bb-sm b-default py-150">
           <span class="gcds-icon-chevron-left"></span>
           <span class="mls"> gcds-icon-chevron-left</span>
         </li>
-        <li class="bb-sm b-default py-200">
+        <li class="bb-sm b-default py-150">
           <span class="gcds-icon-chevron-right"></span>
           <span class="mls"> gcds-icon-chevron-right</span>
         </li>
-        <li class="bb-sm b-default py-200">
+        <li class="bb-sm b-default py-150">
           <span class="gcds-icon-chevron-up"></span>
           <span class="mls"> gcds-icon-chevron-up</span>
         </li>
-        <li class="bb-sm b-default py-200">
+        <li class="bb-sm b-default py-150">
           <span class="gcds-icon-close"></span>
           <span class="mls"> gcds-icon-close</span>
         </li>
-        <li class="bb-sm b-default py-200">
+        <li class="bb-sm b-default py-150">
           <span class="gcds-icon-download"></span>
           <span class="mls"> gcds-icon-download</span>
         </li>
-        <li class="bb-sm b-default py-200">
+        <li class="bb-sm b-default py-150">
           <span class="gcds-icon-email"></span>
           <span class="mls"> gcds-icon-email</span>
         </li>
-        <li class="bb-sm b-default py-200">
+        <li class="bb-sm b-default py-150">
           <span class="gcds-icon-exclamation-circle"></span>
           <span class="mls"> gcds-icon-exclamation-circle</span>
         </li>
-        <li class="bb-sm b-default py-200">
+        <li class="bb-sm b-default py-150">
           <span class="gcds-icon-external"></span>
           <span class="mls"> gcds-icon-external</span>
         </li>
-        <li class="bb-sm b-default py-200">
+        <li class="bb-sm b-default py-150">
           <span class="gcds-icon-information-circle"></span>
           <span class="mls"> gcds-icon-information-circle</span>
         </li>
-        <li class="bb-sm b-default py-200">
+        <li class="bb-sm b-default py-150">
           <span class="gcds-icon-phone"></span>
           <span class="mls"> gcds-icon-phone</span>
         </li>
-        <li class="bb-sm b-default py-200">
+        <li class="bb-sm b-default py-150">
           <span class="gcds-icon-search"></span>
           <span class="mls"> gcds-icon-search</span>
         </li>
-        <li class="bb-sm b-default py-200">
+        <li class="bb-sm b-default py-150">
           <span class="gcds-icon-warning-triangle"></span>
           <span class="mls"> gcds-icon-warning-triangle</span>
         </li>
       </ul>
-    </div>
+    </main>
   </body>
 </html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>GC Design System Fonts Demo</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans&display=swap"
+      rel="stylesheet"
+    />
+
+    <!-- GCDS Utility framework -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-utility@1.5.0/dist/gcds-utility.min.css"
+    />
+
+    <!-- GCDS Icons -->
+    <link rel="stylesheet" href="example.css" />
+  </head>
+  <body>
+    <main class="container-xl mx-auto my-300 lg:my-600 px-300 xl:px-0">
+      <h1 class="mb-300">GC Design System Fonts</h1>
+      <p class="mb-300">GC Design System Fonts provides the fonts used within GC Design System.</p>
+
+      <section class="bt-md mt-600">
+        <h2 class="mt-600 mb-300">Font: Icons</h2>
+        <p class="mb-300">Use the font "GCDS Icons" for any icons. For more details on usage, refer to the <a href="https://github.com/cds-snc/gcds-fonts/blob/main/fonts/icons/README.md">README</a> and <a href="https://github.com/cds-snc/gcds-fonts/blob/main/fonts/icons/LICENSE.txt">license</a> for the "GCDS Icons" font.</p>
+        <ul class="d-grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-300">
+          <li class="bb-sm b-default py-150">
+            <span class="gcds-icon-checkmark-circle"></span>
+            <span class="mls"> gcds-icon-checkmark-circle</span>
+          </li>
+          <li class="bb-sm b-default py-150">
+            <span class="gcds-icon-chevron-down"></span>
+            <span class="mls"> gcds-icon-chevron-down</span>
+          </li>
+          <li class="bb-sm b-default py-150">
+            <span class="gcds-icon-chevron-left"></span>
+            <span class="mls"> gcds-icon-chevron-left</span>
+          </li>
+          <li class="bb-sm b-default py-150">
+            <span class="gcds-icon-chevron-right"></span>
+            <span class="mls"> gcds-icon-chevron-right</span>
+          </li>
+          <li class="bb-sm b-default py-150">
+            <span class="gcds-icon-chevron-up"></span>
+            <span class="mls"> gcds-icon-chevron-up</span>
+          </li>
+          <li class="bb-sm b-default py-150">
+            <span class="gcds-icon-close"></span>
+            <span class="mls"> gcds-icon-close</span>
+          </li>
+          <li class="bb-sm b-default py-150">
+            <span class="gcds-icon-download"></span>
+            <span class="mls"> gcds-icon-download</span>
+          </li>
+          <li class="bb-sm b-default py-150">
+            <span class="gcds-icon-email"></span>
+            <span class="mls"> gcds-icon-email</span>
+          </li>
+          <li class="bb-sm b-default py-150">
+            <span class="gcds-icon-exclamation-circle"></span>
+            <span class="mls"> gcds-icon-exclamation-circle</span>
+          </li>
+          <li class="bb-sm b-default py-150">
+            <span class="gcds-icon-external"></span>
+            <span class="mls"> gcds-icon-external</span>
+          </li>
+          <li class="bb-sm b-default py-150">
+            <span class="gcds-icon-information-circle"></span>
+            <span class="mls"> gcds-icon-information-circle</span>
+          </li>
+          <li class="bb-sm b-default py-150">
+            <span class="gcds-icon-phone"></span>
+            <span class="mls"> gcds-icon-phone</span>
+          </li>
+          <li class="bb-sm b-default py-150">
+            <span class="gcds-icon-search"></span>
+            <span class="mls"> gcds-icon-search</span>
+          </li>
+          <li class="bb-sm b-default py-150">
+            <span class="gcds-icon-warning-triangle"></span>
+            <span class="mls"> gcds-icon-warning-triangle</span>
+          </li>
+        </ul>
+      </section>
+
+      <section class="bt-md mt-600">
+        <h2 class="mt-600 mb-300">Font: Lato</h2>
+        <p class="mb-300">Use the font "Lato" for headings only. Any other text should use the font Noto Sans. For more details on usage, refer to the <a href="https://github.com/cds-snc/gcds-fonts/blob/main/fonts/lato/README.md">README</a> and <a href="https://github.com/cds-snc/gcds-fonts/blob/main/fonts/lato/LICENSE.txt">license</a> for the "Lato" font.</p>
+        <ul class="list-disc">
+          <li class="mb-300">
+            <h1>Heading level 1 (Lato)</h1>
+          </li>
+          <li class="mb-300">
+            <h2>Heading level 2 (Lato)</h2>
+          </li>
+          <li class="mb-300">
+            <h3>Heading level 3 (Lato)</h3>
+          </li>
+          <li class="mb-300">
+            <h4>Heading level 4 (Lato)</h4>
+          </li>
+          <li class="mb-300">
+            <h5>Heading level 5 (Lato)</h5>
+          </li>
+          <li class="mb-300">
+            <h6>Heading level 6 (Lato)</h6>
+          </li>
+        </ul>
+      </section>
+
+      <section class="bt-md mt-600">
+        <h2 class="mt-600 mb-300">Font: Noto Sans</h2>
+        <p class="mb-300">Use the font "Noto Sans" for most text. For more details on usage, refer to the <a href="https://github.com/cds-snc/gcds-fonts/blob/main/fonts/noto-sans/README.md">README</a> and <a href="https://github.com/cds-snc/gcds-fonts/blob/main/fonts/noto-sans/LICENSE.txt">license</a> for the "Noto Sans" font.</p>
+        <ul class="list-disc">
+          <li class="noto-sans-light mb-300">Noto sans - light</li>
+          <li class="noto-sans-light mb-300">
+            <em>Noto sans - light (italic)</em>
+          </li>
+          <li class="noto-sans-regular mb-300">Noto sans - regular</li>
+          <li class="noto-sans-regular mb-300">
+            <em>Noto sans - regular (italic)</em>
+          </li>
+          <li class="noto-sans-medium mb-300">Noto sans - medium</li>
+          <li class="noto-sans-medium mb-300">
+            <em>Noto sans - medium (italic)</em>
+          </li>
+          <li class="noto-sans-semibold mb-300">Noto sans - semibold</li>
+          <li class="noto-sans-semibold mb-300">
+            <em>Noto sans - semibold (italic)</em>
+          </li>
+          <li class="noto-sans-bold mb-300">Noto sans - bold</li>
+          <li class="noto-sans-bold mb-300">
+            <em>Noto sans - bold (italic)</em>
+          </li>
+        </ul>
+      </section>
+
+      <section class="bt-md mt-600">
+        <h2 class="mt-600 mb-300">Font: Noto Sans Mono</h2>
+        <p class="mb-300">Opt to use the monospace font "Noto Sans Mono" when citing code to give specific code examples. For more details on usage, refer to the <a href="https://github.com/cds-snc/gcds-fonts/blob/main/fonts/noto-sans-mono/README.md">README</a> and <a href="https://github.com/cds-snc/gcds-fonts/blob/main/fonts/noto-sans-mono/LICENSE.txt">license</a> for the "Noto Sans Mono" font.</p>
+        <code class="d-block bg-dark text-light p-300">
+          &lt;p&gt;Example code using Noto Sans Mono&lt;/p&gt;
+        </code>
+      </section>
+    </main>
+  </body>
+</html>

--- a/examples/lato/gcds-lato-example.css
+++ b/examples/lato/gcds-lato-example.css
@@ -24,8 +24,3 @@ h6 {
   font-family: "Lato", sans-serif;
   font-weight: 700;
 }
-
-/* Do not copy this code, removing the H1 border for this demo only */
-ul h1:after {
-  display: none;
-}

--- a/examples/lato/gcds-lato-example.html
+++ b/examples/lato/gcds-lato-example.html
@@ -15,29 +15,29 @@
     <link rel="stylesheet" href="gcds-lato-example.css" />
   </head>
   <body>
-    <div class="container-xl mx-auto my-400 lg:my-600 px-400 xl:px-0">
-      <h1 class="mb-400">GC Design System Fonts - Lato</h1>
+    <main class="container-xl mx-auto my-300 lg:my-600 px-300 xl:px-0">
+      <h1 class="mb-300">GC Design System Fonts - Lato</h1>
 
       <ul class="list-disc">
-        <li>
+        <li class="mb-300">
           <h1>Heading level 1 (Lato)</h1>
         </li>
-        <li>
+        <li class="mb-300">
           <h2>Heading level 2 (Lato)</h2>
         </li>
-        <li>
+        <li class="mb-300">
           <h3>Heading level 3 (Lato)</h3>
         </li>
-        <li>
+        <li class="mb-300">
           <h4>Heading level 4 (Lato)</h4>
         </li>
-        <li>
+        <li class="mb-300">
           <h5>Heading level 5 (Lato)</h5>
         </li>
-        <li>
+        <li class="mb-300">
           <h6>Heading level 6 (Lato)</h6>
         </li>
       </ul>
-    </div>
+    </main>
   </body>
 </html>

--- a/examples/noto-sans-mono/gcds-noto-sans-mono-example.html
+++ b/examples/noto-sans-mono/gcds-noto-sans-mono-example.html
@@ -15,12 +15,12 @@
     <link rel="stylesheet" href="gcds-noto-sans-mono-example.css" />
   </head>
   <body>
-    <div class="container-xl mx-auto my-400 lg:my-600 px-400 xl:px-0">
-      <h1 class="mb-400">GC Design System Fonts - Noto Sans Mono</h1>
+    <main class="container-xl mx-auto my-300 lg:my-600 px-300 xl:px-0">
+      <h1 class="mb-300">GC Design System Fonts - Noto Sans Mono</h1>
 
-      <code class="d-block bg-dark text-light p-400">
+      <code class="d-block bg-dark text-light p-300">
         &lt;p&gt;Example code using Noto Sans Mono&lt;/p&gt;
       </code>
-    </div>
+    </main>
   </body>
 </html>

--- a/examples/noto-sans/gcds-noto-sans-example.html
+++ b/examples/noto-sans/gcds-noto-sans-example.html
@@ -15,31 +15,31 @@
     <link rel="stylesheet" href="gcds-noto-sans-example.css" />
   </head>
   <body>
-    <div class="container-xl mx-auto my-400 lg:my-600 px-400 xl:px-0">
-      <h1 class="mb-400">GC Design System Fonts - Noto Sans</h1>
+    <main class="container-xl mx-auto my-300 lg:my-600 px-300 xl:px-0">
+      <h1 class="mb-300">GC Design System Fonts - Noto Sans</h1>
 
       <ul class="list-disc">
-        <li class="noto-sans-light">Noto sans - light</li>
-        <li class="noto-sans-light">
+        <li class="noto-sans-light mb-300">Noto sans - light</li>
+        <li class="noto-sans-light mb-300">
           <em>Noto sans - light (italic)</em>
         </li>
-        <li class="noto-sans-regular">Noto sans - regular</li>
-        <li class="noto-sans-regular">
+        <li class="noto-sans-regular mb-300">Noto sans - regular</li>
+        <li class="noto-sans-regular mb-300">
           <em>Noto sans - regular (italic)</em>
         </li>
-        <li class="noto-sans-medium">Noto sans - medium</li>
-        <li class="noto-sans-medium">
+        <li class="noto-sans-medium mb-300">Noto sans - medium</li>
+        <li class="noto-sans-medium mb-300">
           <em>Noto sans - medium (italic)</em>
         </li>
-        <li class="noto-sans-semibold">Noto sans - semibold</li>
-        <li class="noto-sans-semibold">
+        <li class="noto-sans-semibold mb-300">Noto sans - semibold</li>
+        <li class="noto-sans-semibold mb-300">
           <em>Noto sans - semibold (italic)</em>
         </li>
-        <li class="noto-sans-bold">Noto sans - bold</li>
-        <li class="noto-sans-bold">
+        <li class="noto-sans-bold mb-300">Noto sans - bold</li>
+        <li class="noto-sans-bold mb-300">
           <em>Noto sans - bold (italic)</em>
         </li>
       </ul>
-    </div>
+    </main>
   </body>
 </html>


### PR DESCRIPTION
# Summary | Résumé

This PR adds a font demo which we will use to create a GitHub Page for this repo. It provides an overview of all available fonts. The demo will allow users to preview the different font options.

It also updates the existing demo files for each specific font to use the new spacing classes after the typography & spacing update in December.

## Zenhub ticket

The [Zenhub ticket](https://app.zenhub.com/workspaces/gc-design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/988) for this task.