### PR TITLE
chore: adjust conditional logic for "upload to cdn" steps

### DIFF
--- a/.github/workflows/upload-cdn.yml
+++ b/.github/workflows/upload-cdn.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
       - name: Configure AWS credentials using OIDC
-        if: steps.publish.outputs.id != ''
+        if: github.event.workflow_run.conclusion == 'success'
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
           role-to-assume: arn:aws:iam::307395567143:role/gcds-fonts-apply
@@ -33,7 +33,7 @@ jobs:
           aws-region: ${{ env.CDN_REGION }}
 
       - name: Update CDN
-        if: steps.publish.outputs.id != ''
+        if: github.event.workflow_run.conclusion == 'success'
         run: |
           VERSION="$(cat package.json | jq -r .version)"
           PUBLISHED_PACKAGE="${{ env.PACKAGE_NAME }}@$VERSION"
@@ -48,7 +48,7 @@ jobs:
           aws cloudfront create-invalidation --distribution-id ${{ secrets.CDN_CLOUDFRONT_DIST_ID }} --paths "/*"
 
       - name: Report deployment to Sentinel
-        if: steps.publish.outputs.id != ''
+        if: github.event.workflow_run.conclusion == 'success'
         uses: cds-snc/sentinel-forward-data-action@main
         with:
           input_data: '{"product": "design-system", "sha": "${{ github.sha }}", "version": "${{steps.publish.outputs.id}}", "repository": "${{ github.repository }}", "environment": "production", "status": "${{ job.status }}"}'


### PR DESCRIPTION
# Summary | Résumé

The previous `if: steps.publish.outputs.id != ''` condition in the "Upload to CDN" workflow was checking if an output id was set in the publish step. However, since the publish step doesn't set an id output, this condition was always false, causing certain steps to be skipped.

This update modifies the condition to ensure that the downstream steps are executed when the "Publish fonts" workflow is completed successfully, regardless of the missing ID output.