### PR TITLE
chore: fix failing action because of non-existent file

### DIFF
--- a/.github/workflows/upload-cdn.yml
+++ b/.github/workflows/upload-cdn.yml
@@ -42,8 +42,8 @@ jobs:
           aws s3 sync ./fonts/ s3://${{ env.CDN_BUCKET }}/${{ env.PACKAGE_NAME }}@latest/ --delete
 
           # Check if specific files exist in the root of the CDN bucket for both the versioned and latest paths
-          aws s3api head-object --bucket ${{ env.CDN_BUCKET }} --key "$PUBLISHED_PACKAGE"/package.json
-          aws s3api head-object --bucket ${{ env.CDN_BUCKET }} --key ${{ env.PACKAGE_NAME }}@latest/package.json
+          aws s3api head-object --bucket ${{ env.CDN_BUCKET }} --key "$PUBLISHED_PACKAGE"/icons/gcds-icons.css
+          aws s3api head-object --bucket ${{ env.CDN_BUCKET }} --key ${{ env.PACKAGE_NAME }}@latest/icons/gcds-icons.css
 
           aws cloudfront create-invalidation --distribution-id ${{ secrets.CDN_CLOUDFRONT_DIST_ID }} --paths "/*"
 


### PR DESCRIPTION
# Summary | Résumé

The previous action was looking for a file that didn't get created in the uploading process which caused it to fail. Updated it to use one of the existing font files instead.
