### PR TITLE
fix: update icon font installation instructions + css classes

### DIFF
--- a/fonts/icons/README.md
+++ b/fonts/icons/README.md
@@ -20,12 +20,12 @@ To use GC Design System icons in your project, place the following code in your 
 <!-- GC Design System Fonts - Icons -->
 @font-face {
   font-family: "gcds-icons";
-  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@<version-number>/fonts/icons/gcds-icons.eot");
-  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@<version-number>/fonts/icons/gcds-icons.eot#iefix")
-      format("embedded-opentype"), url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@<version-number>/fonts/icons/gcds-icons.ttf")
+  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@<version-number>/icons/gcds-icons.eot");
+  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@<version-number>/icons/gcds-icons.eot#iefix")
+      format("embedded-opentype"), url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@<version-number>/icons/gcds-icons.ttf")
       format("truetype"),
-    url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@<version-number>/fonts/icons/gcds-icons.woff")
-      format("woff"), url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@<version-number>/fonts/icons/gcds-icons.svg")
+    url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@<version-number>/icons/gcds-icons.woff")
+      format("woff"), url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@<version-number>/icons/gcds-icons.svg")
       format("svg");
   font-weight: normal;
   font-style: normal;
@@ -244,12 +244,12 @@ Pour utiliser les icônes de Système de design GC dans votre projet, placez le 
 <!-- Polices de Système de design GC — Icônes -->
 @font-face {
   font-family: "gcds-icons";
-  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@<version-number>/fonts/icons/gcds-icons.eot");
-  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@<version-number>/fonts/icons/gcds-icons.eot#iefix")
-      format("embedded-opentype"), url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@<version-number>/fonts/icons/gcds-icons.ttf")
+  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@<version-number>/icons/gcds-icons.eot");
+  src: url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@<version-number>/icons/gcds-icons.eot#iefix")
+      format("embedded-opentype"), url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@<version-number>/icons/gcds-icons.ttf")
       format("truetype"),
-    url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@<version-number>/fonts/icons/gcds-icons.woff")
-      format("woff"), url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@<version-number>/fonts/icons/gcds-icons.svg")
+    url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@<version-number>/icons/gcds-icons.woff")
+      format("woff"), url("https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-fonts@<version-number>/icons/gcds-icons.svg")
       format("svg");
   font-weight: normal;
   font-style: normal;

--- a/fonts/icons/gcds-icons.css
+++ b/fonts/icons/gcds-icons.css
@@ -28,6 +28,10 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+.gcds-icon-checkmark-circle:before {
+  content: "\e908";
+}
+
 .gcds-icon-chevron-down:before {
   content: "\e900";
 }
@@ -44,58 +48,38 @@
   content: "\e903";
 }
 
-.gcds-icon-external:before {
-  content: "\e904";
-}
-
-.gcds-icon-email:before {
-  content: "\e905";
+.gcds-icon-close:before {
+  content: "\e90b";
 }
 
 .gcds-icon-download:before {
   content: "\e906";
 }
 
-.gcds-icon-warning-triangle-outline:before {
-  content: "\e907";
+.gcds-icon-email:before {
+  content: "\e905";
 }
 
-.gcds-icon-search:before {
-  content: "\e908";
-}
-
-.gcds-icon-checkmark-circle-solid:before {
+.gcds-icon-exclamation-circle:before {
   content: "\e909";
 }
 
-.gcds-icon-exclamation-circle-solid:before {
+.gcds-icon-external:before {
+  content: "\e904";
+}
+
+.gcds-icon-information-circle:before {
   content: "\e90a";
 }
 
-.gcds-icon-information-circle-solid:before {
-  content: "\e90b";
-}
-
-.gcds-icon-close:before {
+.gcds-icon-phone:before {
   content: "\e90c";
 }
 
-.gcds-icon-phone:before {
+.gcds-icon-search:before {
+  content: "\e907";
+}
+
+.gcds-icon-warning-triangle:before {
   content: "\e90d";
-}
-
-.gcds-icon-warning-triangle-solid:before {
-  content: "\e90e";
-}
-
-.gcds-icon-checkmark-circle-outline:before {
-  content: "\e90f";
-}
-
-.gcds-icon-exclamation-circle-outline:before {
-  content: "\e910";
-}
-
-.gcds-icon-information-circle-outline:before {
-  content: "\e911";
 }


### PR DESCRIPTION
# Summary | Résumé

While updating the icon component today with the new icon font, I realized that the installation instructions for the icon font needed revision. We decided to change the CDN path for the icon font files, which means the `fonts` part in the URL needs to be removed. Additionally, we updated the icon font classes, which also required changes to the icon.css file.