### PR TITLE
fix: update icon class name to match figma value

### DIFF
--- a/docs/example.css
+++ b/docs/example.css
@@ -65,7 +65,7 @@
   content: "\e904";
 }
 
-.gcds-icon-information-circle:before {
+.gcds-icon-info-circle:before {
   content: "\e90a";
 }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -76,8 +76,8 @@
             <span class="mls"> gcds-icon-external</span>
           </li>
           <li class="bb-sm b-default py-150">
-            <span class="gcds-icon-information-circle"></span>
-            <span class="mls"> gcds-icon-information-circle</span>
+            <span class="gcds-icon-info-circle"></span>
+            <span class="mls"> gcds-icon-info-circle</span>
           </li>
           <li class="bb-sm b-default py-150">
             <span class="gcds-icon-phone"></span>

--- a/examples/icons/gcds-icons-example.css
+++ b/examples/icons/gcds-icons-example.css
@@ -64,7 +64,7 @@
   content: "\e904";
 }
 
-.gcds-icon-information-circle:before {
+.gcds-icon-info-circle:before {
   content: "\e90a";
 }
 

--- a/examples/icons/gcds-icons-example.html
+++ b/examples/icons/gcds-icons-example.html
@@ -72,8 +72,8 @@
           <span class="mls"> gcds-icon-external</span>
         </li>
         <li class="bb-sm b-default py-150">
-          <span class="gcds-icon-information-circle"></span>
-          <span class="mls"> gcds-icon-information-circle</span>
+          <span class="gcds-icon-info-circle"></span>
+          <span class="mls"> gcds-icon-info-circle</span>
         </li>
         <li class="bb-sm b-default py-150">
           <span class="gcds-icon-phone"></span>

--- a/fonts/icons/README.md
+++ b/fonts/icons/README.md
@@ -86,7 +86,7 @@ To use GC Design System icons in your project, place the following code in your 
   content: "\e904";
 }
 
-.gcds-icon-information-circle:before {
+.gcds-icon-info-circle:before {
   content: "\e90a";
 }
 
@@ -187,7 +187,7 @@ Place the following code in your CSS and replace `path/to/node_modules` with the
   content: "\e904";
 }
 
-.gcds-icon-information-circle:before {
+.gcds-icon-info-circle:before {
   content: "\e90a";
 }
 
@@ -310,7 +310,7 @@ Pour utiliser les icônes de Système de design GC dans votre projet, placez le 
   content: "\e904";
 }
 
-.gcds-icon-information-circle:before {
+.gcds-icon-info-circle:before {
   content: "\e90a";
 }
 
@@ -411,7 +411,7 @@ Placez le code suivant dans votre CSS et remplacez `path/to/node_modules` par l'
   content: "\e904";
 }
 
-.gcds-icon-information-circle:before {
+.gcds-icon-info-circle:before {
   content: "\e90a";
 }
 

--- a/fonts/icons/gcds-icons.css
+++ b/fonts/icons/gcds-icons.css
@@ -68,7 +68,7 @@
   content: "\e904";
 }
 
-.gcds-icon-information-circle:before {
+.gcds-icon-info-circle:before {
   content: "\e90a";
 }
 


### PR DESCRIPTION
# Summary | Résumé

Updating the icon name `gcds-icon-information-circle` to `gcds-icon-info-circle` to match the Figma value.